### PR TITLE
Add static mobile mini-game "言い訳バトル：信用残高ゼロ" (HTML/CSS/JS)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,104 @@
+(() => {
+  const data = window.GAME_DATA;
+  const app = document.getElementById('app');
+
+  const state = {
+    screen: 'title', selectedCharacter: null, questionIndex: 0, trust: 100, affection: 50,
+    anger: 0, laugh: 0, chaos: 0, safeCount: 0, jokeCount: 0, chaosCount: 0,
+    lastCard: null, lastReaction: '', expression: 'normal', lockCards: false, canNext: false, copyStatus: ''
+  };
+
+  const clamp = (v, min, max) => Math.min(max, Math.max(min, v));
+  const tname = { safe: '安全', joke: '半ボケ', chaos: '全力ボケ' };
+
+  function resetBattle(charId) { Object.assign(state, { screen: 'game', selectedCharacter: charId, questionIndex: 0, trust: 100, affection: 50, anger: 0, laugh: 0, chaos: 0, safeCount: 0, jokeCount: 0, chaosCount: 0, lastCard: null, lastReaction: '', expression: 'normal', lockCards: false, canNext: false, copyStatus: '' }); render(); }
+  function getChar() { return data.characters.find(c => c.id === state.selectedCharacter); }
+  function imgPath() { return `assets/characters/${state.selectedCharacter}_${state.expression}.png`; }
+
+  function resultType() {
+    if (state.trust >= 70 && state.affection >= 70) return 'good';
+    if (state.trust >= 40 && state.affection >= 70) return 'weird_liked';
+    if (state.trust >= 70 && state.affection < 40) return 'business_survive';
+    if (state.trust < 40 && state.affection < 40) return 'danger';
+    return 'normal';
+  }
+  function titleJudge() {
+    if (state.trust >= 80 && state.affection >= 70) return '誠実なる言い逃れ職人';
+    if (state.trust < 30 && state.affection >= 70) return 'なぜか許される人';
+    if (state.laugh >= 35 && state.chaos < 25) return '謝罪芸人';
+    if (state.chaos >= 50) return '説明不能の異常存在';
+    if (state.anger >= 50) return '信用残高マイナスの妖精';
+    if (state.safeCount >= 4) return '正直すぎる生還者';
+    if (state.jokeCount >= 4) return '空気で渡る綱渡り師';
+    if (state.chaosCount >= 4) return '時空を越えた問題社員';
+    if (state.trust >= 60 && state.affection < 40) return '業務だけは守った人';
+    return '普通に怒られた人';
+  }
+  const finalExp = { good: 'smile', weird_liked: 'confused', business_survive: 'normal', danger: 'angry', normal: 'confused' };
+
+  function chooseCard(cardIndex) {
+    if (state.lockCards) return;
+    const q = data.questions[state.questionIndex]; const card = q.cards[cardIndex]; const cid = state.selectedCharacter;
+    state.lockCards = true; state.lastCard = card; state.canNext = false;
+    state.trust = clamp(state.trust + card.effects.trust, 0, 100);
+    state.affection = clamp(state.affection + card.affection[cid], 0, 100);
+    state.anger = Math.max(0, state.anger + card.effects.anger);
+    state.laugh = Math.max(0, state.laugh + card.effects.laugh);
+    state.chaos = Math.max(0, state.chaos + card.effects.chaos);
+    if (card.type === 'safe') state.safeCount++; if (card.type === 'joke') state.jokeCount++; if (card.type === 'chaos') state.chaosCount++;
+    state.expression = card.expression[cid]; state.lastReaction = card.reaction[cid]; render();
+    setTimeout(() => { state.canNext = true; render(); }, 1000);
+  }
+
+  function nextStep() { state.lastCard = null; state.lastReaction = ''; state.lockCards = false; state.canNext = false; state.questionIndex++; if (state.questionIndex >= data.questions.length) { state.screen = 'result'; state.expression = finalExp[resultType()]; } render(); }
+
+  async function copyResult() {
+    const c = getChar(); const type = resultType(); const comment = data.resultComments[c.id][type];
+    const txt = `「${data.title}」\n相手：${c.name}\n称号：${titleJudge()}\n信用残高：${state.trust}\n好感度：${state.affection}\n総評：${comment}`;
+    try { await navigator.clipboard.writeText(txt); state.copyStatus = 'コピーしました'; } catch { state.copyStatus = 'コピーに失敗しました'; }
+    render();
+  }
+
+  function portrait(charName) {
+    return `<div class="portrait"><img src="${imgPath()}" alt="${charName}" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"><div class="fallback" style="display:none">${charName}<br>画像準備中</div></div>`;
+  }
+
+  function render() {
+    if (state.screen === 'title') {
+      app.innerHTML = `<div class="center"><h1 class="title">${data.title}</h1><p class="subtitle">${data.subtitle}</p><button class="btn" id="start">はじめる</button></div>`;
+      document.getElementById('start').onclick = () => { state.screen = 'select'; render(); };
+      return;
+    }
+    if (state.screen === 'select') {
+      app.innerHTML = `<h2 class="center">対戦相手を選択</h2><div class="char-grid">${data.characters.map(c => `<button class="card" data-id="${c.id}"><div class="char-name">${c.name}</div><div class="role">${c.role}</div><p>${c.description}</p><div class="small">得意タイプ：${c.specialty}</div></button>`).join('')}</div>`;
+      [...app.querySelectorAll('[data-id]')].forEach(b => b.onclick = () => resetBattle(b.dataset.id));
+      return;
+    }
+    if (state.screen === 'game') {
+      const q = data.questions[state.questionIndex]; const c = getChar();
+      app.innerHTML = `<div class="top"><div class="stage">${state.questionIndex + 1}/${data.questions.length}</div>
+      <div class="meters"><div>信用残高 ${state.trust}</div><div class="meter"><div class="fill trust" style="width:${state.trust}%"></div></div>
+      <div>好感度 ${state.affection}</div><div class="meter"><div class="fill affection" style="width:${state.affection}%"></div></div></div></div>
+      <div class="character-area">${portrait(c.name)}<div class="bubble"><strong>${q.title}</strong><br>${q.situation}</div>${state.lastReaction ? `<div class="bubble">${state.lastReaction}</div>` : ''}</div>
+      ${state.lastCard ? '<div class="flash">言い訳発動！</div>' : ''}
+      <div class="cards">${q.cards.map((card, i) => `<button class="excuse ${card.type} ${state.lastCard && state.lastCard.id === card.id ? 'selected' : ''} ${state.lockCards && (!state.lastCard || state.lastCard.id !== card.id) ? 'locked' : ''}" data-i="${i}" ${state.lockCards ? 'disabled' : ''}><div class="type">${tname[card.type]}</div><strong>${card.name}</strong><p>${card.text}</p><div class="fx">${card.type === 'safe' ? '堅実・低リスク' : card.type === 'joke' ? '笑い狙い・中リスク' : '予測不能・高リスク'}</div></button>`).join('')}</div>
+      ${state.canNext ? '<button class="btn" id="nextBtn">次へ</button>' : ''}`;
+      [...app.querySelectorAll('[data-i]')].forEach(b => b.onclick = () => chooseCard(Number(b.dataset.i)));
+      const n = document.getElementById('nextBtn'); if (n) n.onclick = nextStep;
+      return;
+    }
+    if (state.screen === 'result') {
+      const c = getChar(); const type = resultType(); const title = titleJudge(); const comment = data.resultComments[c.id][type];
+      app.innerHTML = `<h2 class="center">結果発表</h2>${portrait(c.name)}
+      <div class="result-stat"><span>信用残高</span><strong>${state.trust}</strong></div>
+      <div class="result-stat"><span>好感度</span><strong>${state.affection}</strong></div>
+      <div class="result-stat"><span>称号</span><strong>${title}</strong></div>
+      <div class="bubble">${comment}</div>
+      <div style="display:grid;gap:8px;margin-top:12px"><button class="btn" id="retry">もう一度同じ相手に挑む</button><button class="btn secondary" id="backSel">キャラ選択に戻る</button><button class="btn" id="copy">結果をコピー</button><div class="copy-status">${state.copyStatus || ''}</div></div>`;
+      document.getElementById('retry').onclick = () => resetBattle(c.id);
+      document.getElementById('backSel').onclick = () => { state.screen = 'select'; render(); };
+      document.getElementById('copy').onclick = copyResult;
+    }
+  }
+  render();
+})();

--- a/game-data.js
+++ b/game-data.js
@@ -1,0 +1,41 @@
+window.GAME_DATA = {
+  title: '言い訳バトル：信用残高ゼロ',
+  subtitle: 'その言い訳、美少女に通りますか？',
+  characters: [
+    { id: 'rena', name: '白銀 怜奈', role: '上司', description: '信用重視のクール上司。通じる言い訳は少ない。', specialty: '安全' },
+    { id: 'mio', name: '日向 ミオ', role: '同僚', description: '空気重視のノリ良き同僚。笑えたら少し許す。', specialty: '半ボケ' },
+    { id: 'koharu', name: '淡島 こはる', role: '後輩', description: '誠実さ重視の後輩。雑なごまかしには弱い。', specialty: '安全・半ボケ' }
+  ],
+  resultComments: {
+    rena: { good: '言い訳は多かったですが、最低限の誠意は見えました。次は結果で返してください。', weird_liked: '信用は削れました。ただ、妙な胆力だけは記憶に残りました。', business_survive: '業務上は許容範囲です。人としての評価は、まだ保留します。', danger: '説明を重ねるほど、評価が静かに沈んでいきました。', normal: '今回は見逃します。次に同じ説明は通りません。' },
+    mio: { good: 'まあまあ許せるライン。次やったらネタにするからね。', weird_liked: '信用は危ないけど、飲み会の話題としては優秀。', business_survive: '仕事としてはセーフ。でも、おもしろ成分が足りない。', danger: '面白いけど、同じチームには少し怖い。', normal: '怒るほどではないけど、いじる材料は増えた。' },
+    koharu: { good: 'ちゃんと向き合ってくれた感じがしました。少し安心しました。', weird_liked: 'よくわからなかったです。でも、なんだか忘れられません。', business_survive: '問題はなさそうです。でも、少しだけ距離を置いて見守ります。', danger: '信じたい気持ちはありました。でも、途中で迷子になりました。', normal: 'たぶん大丈夫です。たぶん、です。' }
+  },
+  questions: [
+    { title: '遅刻した', situation: '始業時間を過ぎて到着。選んだ相手が、静かにこちらを見ています。', cards: [
+      { id: 'late_safe', type: 'safe', name: '正直な寝坊', text: 'すみません、寝坊しました。次から対策します。', effects: { trust: -6, anger: 4, laugh: 0, chaos: 0 }, affection: { rena: 7, mio: 2, koharu: 6 }, expression: { rena: 'normal', mio: 'confused', koharu: 'normal' }, reaction: { rena: '正直なのは評価します。次は対策まで先に出してください。', mio: '潔いけど、寝坊は寝坊やな。コーヒー買ってきて。', koharu: '正直に言ってくれたので、少し安心しました。' } },
+      { id: 'late_joke', type: 'joke', name: '脳内出社', text: '気持ちは定時に着いていました。体が遅れました。', effects: { trust: -12, anger: 8, laugh: 8, chaos: 3 }, affection: { rena: -4, mio: 10, koharu: 1 }, expression: { rena: 'angry', mio: 'smile', koharu: 'confused' }, reaction: { rena: '気持ちだけでは勤怠に反映されません。', mio: '体が遅刻してるの、もうほぼ全部やん。', koharu: 'えっと……気持ちは受け取りました。' } },
+      { id: 'late_chaos', type: 'chaos', name: '時空の乗換ミス', text: '乗る電車を間違えて、少し別の時間軸にいました。', effects: { trust: -22, anger: 14, laugh: 6, chaos: 16 }, affection: { rena: -12, mio: 4, koharu: -5 }, expression: { rena: 'angry', mio: 'confused', koharu: 'confused' }, reaction: { rena: '時間軸より、出社時刻を確認してください。', mio: '別の時間軸でも遅刻してそう。', koharu: 'すごい話ですけど、遅刻は遅刻ですよね……。' } }
+    ]},
+    { title: 'メール返信を忘れた', situation: '大事なメールに返信していないことが発覚しました。', cards: [
+      { id: 'mail_safe', type: 'safe', name: '確認遅れ', text: '確認していたのですが、返信が遅れました。すぐ対応します。', effects: { trust: -5, anger: 3, laugh: 0, chaos: 0 }, affection: { rena: 8, mio: 1, koharu: 7 }, expression: { rena: 'normal', mio: 'normal', koharu: 'smile' }, reaction: { rena: '対応が早ければ、まだ取り戻せます。', mio: 'まあ、それが一番マシなやつやね。', koharu: 'すぐ返してくれるなら、大丈夫だと思います。' } },
+      { id: 'mail_joke', type: 'joke', name: '脳内送信済み', text: '返信文を考えすぎて、脳内では送信完了していました。', effects: { trust: -10, anger: 6, laugh: 9, chaos: 3 }, affection: { rena: -2, mio: 11, koharu: 3 }, expression: { rena: 'confused', mio: 'smile', koharu: 'normal' }, reaction: { rena: '脳内ではなく、送信ボタンを押してください。', mio: 'ある。いや、あるけど許されるかは別。', koharu: '考えてくれていたのは、ちょっと伝わりました。' } },
+      { id: 'mail_chaos', type: 'chaos', name: 'メール熟成中', text: '返信を寝かせることで、味に深みを出していました。', effects: { trust: -20, anger: 13, laugh: 7, chaos: 14 }, affection: { rena: -11, mio: 5, koharu: -4 }, expression: { rena: 'angry', mio: 'smile', koharu: 'confused' }, reaction: { rena: 'メールはワインではありません。', mio: '熟成させた結果、相手の怒りも深くなってるわ。', koharu: '味より、返信がほしかったです……。' } }
+    ]},
+    { title: '締切を過ぎた', situation: '提出期限を過ぎた資料について、説明を求められています。', cards: [
+      { id: 'deadline_safe', type: 'safe', name: '進捗と謝罪', text: '遅れて申し訳ありません。現在ここまで進んでいます。', effects: { trust: -8, anger: 5, laugh: 0, chaos: 0 }, affection: { rena: 9, mio: 2, koharu: 8 }, expression: { rena: 'normal', mio: 'normal', koharu: 'smile' }, reaction: { rena: '遅延報告としては最低限整っています。次は先に共有してください。', mio: '遅れたけど、状況出せるだけまだ人間。', koharu: '進んでいるなら、少し安心しました。' } },
+      { id: 'deadline_joke', type: 'joke', name: '締切との距離感', text: '締切と向き合いすぎて、逆に見失いました。', effects: { trust: -15, anger: 10, laugh: 8, chaos: 5 }, affection: { rena: -6, mio: 9, koharu: -1 }, expression: { rena: 'angry', mio: 'smile', koharu: 'confused' }, reaction: { rena: '見失う前に、共有してください。', mio: '距離感バグってる恋愛相談みたいになってる。', koharu: '向き合っていたなら、もう少し早く言ってほしかったです。' } },
+      { id: 'deadline_chaos', type: 'chaos', name: '未来からの提出', text: '未来の自分は完成させています。今、追いついています。', effects: { trust: -25, anger: 16, laugh: 5, chaos: 18 }, affection: { rena: -14, mio: 3, koharu: -8 }, expression: { rena: 'angry', mio: 'confused', koharu: 'confused' }, reaction: { rena: '未来ではなく、今日の提出物を見せてください。', mio: '未来の自分にだけ仕事させるな。', koharu: '未来の話より、今の進捗が知りたいです……。' } }
+    ]},
+    { title: '会議資料を読んでいない', situation: '会議が始まった直後、資料を読んでいないことに気づきました。', cards: [
+      { id: 'meeting_safe', type: 'safe', name: '未読申告', text: 'すみません、読み込み不足です。要点を確認させてください。', effects: { trust: -7, anger: 5, laugh: 0, chaos: 0 }, affection: { rena: 8, mio: 1, koharu: 7 }, expression: { rena: 'normal', mio: 'normal', koharu: 'smile' }, reaction: { rena: '正直に言った点は評価します。会議中に取り戻してください。', mio: 'まあ、黙って知った顔するよりはマシ。', koharu: '確認しようとしてくれるなら、助かります。' } },
+      { id: 'meeting_joke', type: 'joke', name: '初見の強み', text: '初見だからこそ、ユーザー目線で参加できます。', effects: { trust: -13, anger: 8, laugh: 9, chaos: 5 }, affection: { rena: -5, mio: 10, koharu: 1 }, expression: { rena: 'angry', mio: 'smile', koharu: 'confused' }, reaction: { rena: 'その言い方で、準備不足は消えません。', mio: 'ものは言いよう選手権なら決勝いける。', koharu: '前向きなのは、少しだけいいと思います。' } },
+      { id: 'meeting_chaos', type: 'chaos', name: '白紙の器', text: '何も入っていない分、先入観なく受け止められます。', effects: { trust: -23, anger: 15, laugh: 5, chaos: 17 }, affection: { rena: -13, mio: 2, koharu: -7 }, expression: { rena: 'angry', mio: 'confused', koharu: 'confused' }, reaction: { rena: '白紙なのは資料ではなく、準備状況ですね。', mio: '器はきれいでも、中身が空やん。', koharu: '先入観より、資料の内容がほしいです……。' } }
+    ]},
+    { title: '飲み会を断りたい', situation: '業務後の飲み会に誘われました。できれば帰りたい空気です。', cards: [
+      { id: 'drink_safe', type: 'safe', name: '予定あり', text: '今日は先約があるので、また次回お願いします。', effects: { trust: -2, anger: 1, laugh: 0, chaos: 0 }, affection: { rena: 6, mio: 3, koharu: 6 }, expression: { rena: 'smile', mio: 'normal', koharu: 'smile' }, reaction: { rena: '問題ありません。予定管理ができているなら十分です。', mio: 'まあ、次回って言ったからには次回な。', koharu: 'ちゃんと伝えてくれるなら、大丈夫です。' } },
+      { id: 'drink_joke', type: 'joke', name: '肝臓の有給', text: '今日は肝臓に有給を取らせています。', effects: { trust: -6, anger: 2, laugh: 11, chaos: 4 }, affection: { rena: 1, mio: 12, koharu: 5 }, expression: { rena: 'confused', mio: 'smile', koharu: 'smile' }, reaction: { rena: '体調管理としては、言い方以外は正しいです。', mio: '肝臓ホワイト企業化計画、支持するわ。', koharu: '体を大事にするのは、いいことだと思います。' } },
+      { id: 'drink_chaos', type: 'chaos', name: '観葉植物会議', text: '家の観葉植物と今後の方針を話し合う予定です。', effects: { trust: -14, anger: 7, laugh: 8, chaos: 15 }, affection: { rena: -7, mio: 7, koharu: 2 }, expression: { rena: 'angry', mio: 'smile', koharu: 'confused' }, reaction: { rena: '植物との会議より、予定ありで十分です。', mio: 'その会議、議事録だけ見たい。', koharu: '植物を大切にしているのは、少し素敵です。' } }
+    ]}
+  ]
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>言い訳バトル：信用残高ゼロ</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <section id="app" class="screen"></section>
+    </main>
+
+    <script src="game-data.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,35 @@
+:root {
+  --bg: linear-gradient(180deg, #f6eeff, #e7f3ff);
+  --panel: #ffffffdd;
+  --text: #2d2a37;
+  --safe: #74c69d;
+  --joke: #f4a261;
+  --chaos: #e76f51;
+}
+*{box-sizing:border-box} body{margin:0;font-family:-apple-system,BlinkMacSystemFont,'Hiragino Sans','Noto Sans JP',sans-serif;background:var(--bg);color:var(--text)}
+.app-shell{max-width:430px;margin:0 auto;min-height:100dvh;padding:12px}
+.screen{background:var(--panel);border-radius:20px;min-height:calc(100dvh - 24px);padding:14px;box-shadow:0 8px 26px #5f6d9a33}
+.center{text-align:center}
+.title{font-size:1.8rem;margin:10px 0 4px}.subtitle{color:#6c5f8d;margin-bottom:20px}
+.btn{width:100%;padding:14px;border:none;border-radius:14px;font-weight:700;font-size:1rem;background:#5b6ef5;color:#fff;box-shadow:0 5px 14px #4c56bb4a}
+.btn.secondary{background:#8b8fb3}.btn:disabled{opacity:.5}
+.char-grid{display:grid;gap:12px}
+.card{border-radius:16px;padding:12px;background:#fff;box-shadow:0 6px 18px #0000001a;border:2px solid #ece9ff}
+.char-name{font-weight:800}.role{font-size:.9rem;color:#6b668a}
+.top{display:grid;gap:8px}
+.meters{display:grid;gap:6px}.meter{background:#ececf6;border-radius:999px;height:12px;overflow:hidden}.fill{height:100%;transition:width .45s ease}
+.trust{background:#5aa9ff}.affection{background:#ff7ab6}
+.stage{font-weight:700}
+.character-area{margin:8px 0}
+.portrait{height:240px;border-radius:16px;background:#f1f4ff;display:flex;align-items:center;justify-content:center;overflow:hidden;position:relative}
+.portrait img{width:100%;height:100%;object-fit:cover}.fallback{padding:10px;text-align:center;font-weight:700;color:#5d6390}
+.bubble{margin-top:8px;background:#fff;border-radius:14px;padding:10px;border:1px solid #dadbf2}
+.cards{display:grid;gap:10px;margin-top:12px}
+.excuse{border-radius:14px;padding:12px;border:2px solid transparent;transition:transform .2s,opacity .2s;border-left-width:8px;min-height:120px}
+.excuse.safe{background:#effcf4;border-color:#a2e6c3}.excuse.joke{background:#fff4e8;border-color:#ffc98f}.excuse.chaos{background:#fff0ec;border-color:#ffab96}
+.excuse.selected{transform:scale(1.03)}.excuse.locked{opacity:.45;pointer-events:none}
+.type{font-size:.78rem;font-weight:700}.fx{font-size:.8rem;color:#6e678b}
+.flash{margin:10px 0;text-align:center;font-weight:900;color:#e14585;animation:pop .6s ease}@keyframes pop{0%{transform:scale(.7);opacity:0}100%{transform:scale(1);opacity:1}}
+.result-stat{display:grid;grid-template-columns:1fr auto;gap:8px;background:#fff;border-radius:12px;padding:10px;margin-top:8px}
+.copy-status{font-size:.9rem;color:#2c8d56;min-height:1.2em;margin-top:6px}
+.small{font-size:.9rem;color:#625b80}


### PR DESCRIPTION
### Motivation
- 実機（スマホ縦）で動く、GitHub Pages 配置可能な静的ブラウザミニゲームを仕様どおりに実装するため。 
- 立ち絵が後から差し替えられる想定で、画像がなくてもプレイ可能なフォールバックを含めるため。 
- カード選択での数値変化・表情・リアクション・結果判定までの一連のゲーム体験をブラウザのみで完結させるため。 

### Description
- 新規ファイルを追加してゲームを実装し、UI/ロジック/データを分離して `index.html`, `styles.css`, `game-data.js`, `app.js` を作成しました。 
- `game-data.js` に 3 キャラ情報、5 問分の全カードデータ（効果、キャラ別好感度補正、表情、リアクション）およびキャラ別総評を仕様通りに格納しました。 
- `app.js` で画面遷移（タイトル→キャラ選択→ゲーム→結果）、状態管理（信用残高・好感度・怒り・笑い・カオス・選択回数など）、カード選択時のロック/演出/1 秒後の `次へ` 解放、ゲージ/表情/吹き出し更新を実装しました。 
- 立ち絵は `assets/characters/<id>_<expression>.png` を参照しつつ、`onerror` フォールバックで代替パネルを表示する耐障害実装と、結果のコピー機能（`navigator.clipboard` を用いた成功/失敗表示）を追加しました。 

### Testing
- 自動構文チェックとして `node --check app.js` が成功しました。 
- 自動構文チェックとして `node --check game-data.js` が成功しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f941a54fe0832fbe0a28db82948a34)